### PR TITLE
chore(renovate): add shared preset config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,14 @@
+{
+  // renovate.json5 — managed by blavity/renovate-config onboarding
+  // Extends the org-wide shared preset. Add repo-specific overrides below.
+  // Preset docs: https://github.com/blavity/renovate-config
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["github>blavity/renovate-config"],
+  packageRules: [
+    {
+      // Group Go module updates
+      matchManagers: ["gomod"],
+      groupName: "go-modules",
+    }
+  ]
+}


### PR DESCRIPTION
## Renovate onboarding — shared preset

This PR configures Renovate to use the [Blavity shared preset](https://github.com/blavity/renovate-config).

**Previous config status:** No Renovate config
**Detected stacks:** docker, github-actions, go

### What this config does

- Extends `github>blavity/renovate-config` for org-wide defaults (schedules, automerge rules, grouping, merge confidence badges, OSV vulnerability alerts)
- Adds stack-specific `packageRules` grouping where applicable

### What the shared preset provides

- Business-hours schedule (6am–4pm ET weekdays)
- Patch/minor automerge after CI; major requires review
- Security vulnerability alerts (immediate, bypass schedule)
- Merge confidence badges on all PRs
- Lock file maintenance on Saturday mornings
- GitHub Actions digest pinning

---
_Opened by [onboard.js](https://github.com/blavity/renovate-config/blob/main/scripts/onboard.js)_
