### PR TITLE
docs(license,readme): update copyright years and add trademark disclaimer

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,9 @@
 MIT License
 
 Portions of this software are derived from digitalocean/app_action
-(https://github.com/digitalocean/app_action), Copyright (c) 2024 DigitalOcean, LLC.
+(https://github.com/digitalocean/app_action), Copyright (c) 2024–2026 DigitalOcean, LLC.
 
-All modifications and additions Copyright (c) 2024 Blavity, Inc.
+All modifications and additions Copyright (c) 2024–2026 Blavity, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ This action uses [Semantic Versioning](https://semver.org/). Pin to a major tag 
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
+## Trademarks
+
+DigitalOcean and App Platform are trademarks or registered trademarks of DigitalOcean, LLC. Blavity, Inc. is not affiliated with, endorsed by, or sponsored by DigitalOcean, LLC. All other trademarks are the property of their respective owners.
+
 ## License
 
-MIT — see [LICENSE](LICENSE). Portions derived from [digitalocean/app_action](https://github.com/digitalocean/app_action), Copyright (c) 2024 DigitalOcean, LLC.
+MIT — see [LICENSE](LICENSE). Portions derived from [digitalocean/app_action](https://github.com/digitalocean/app_action), Copyright (c) 2024–2026 DigitalOcean, LLC.


### PR DESCRIPTION
## Summary
- Update copyright years from 2024 to 2024–2026 in LICENSE and README
- Add Trademarks section to README clarifying Blavity, Inc. is not affiliated with, endorsed by, or sponsored by DigitalOcean, LLC

## Test plan
- [ ] Verify LICENSE renders correctly
- [ ] Verify README trademark section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)