### PR TITLE
fix(ci): use GITHUB_TOKEN for release-please instead of GitHub App

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,14 +32,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.RELEASE_AGENT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_AGENT_APP_PRIVATE_KEY }}
-
       - name: Run Release Please
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Replaces the `actions/create-github-app-token` step in `release-please.yml` with the built-in `secrets.GITHUB_TOKEN`.

## Why

The org-level `RELEASE_AGENT_APP_PRIVATE_KEY` secret, if leaked, would give an attacker the ability to generate tokens with that App's permissions across the entire org — a high blast-radius credential. For release-please on a single repo, the built-in `GITHUB_TOKEN` (scoped to this repo only) is sufficient and carries zero cross-repo risk.

This change was applied to `blavity/smartformat-validate-action` first, where it unblocked a failing Release Please workflow and confirmed the approach works correctly.

## Changes

- `.github/workflows/release-please.yml`: remove `Generate GitHub App Token` step, pass `secrets.GITHUB_TOKEN` directly to `release-please-action`

## No functional change

Release Please behaviour is identical — it still creates release PRs, pushes tags, and creates GitHub Releases. Only the token source changes.