### PR TITLE
fix(ci): add workflow_dispatch to release.yml for manual retrigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,5 +88,5 @@ jobs:
           MAJOR=$(echo "$TAG" | sed 's/\(v[0-9]*\)\..*/\1/')
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -fa "$MAJOR" -m "Update $MAJOR to $TAG"
+          git tag -fa "$MAJOR" -m "Update $MAJOR to $TAG" "$TAG"
           git push origin "$MAJOR" --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,12 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing semver tag to build and publish (e.g. v1.1.0)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -29,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Log in to GHCR
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -40,10 +48,14 @@ jobs:
       - name: Derive image tags
         id: tags
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.tag || github.ref_name }}
           REPO_OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
+          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::tag must match v<major>.<minor>.<patch>, got: $TAG"
+            exit 1
+          fi
           MAJOR=$(echo "$TAG" | sed 's/\(v[0-9]*\)\..*/\1/')
           echo "versioned=ghcr.io/${REPO_OWNER}/do-app-action:${TAG}" >> "$GITHUB_OUTPUT"
           echo "major=ghcr.io/${REPO_OWNER}/do-app-action:${MAJOR}" >> "$GITHUB_OUTPUT"
@@ -71,7 +83,7 @@ jobs:
 
       - name: Move floating major tag
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           MAJOR=$(echo "$TAG" | sed 's/\(v[0-9]*\)\..*/\1/')
           git config user.name  "github-actions[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
 
       - name: Move floating major tag


### PR DESCRIPTION
## Problem

The `release.yml` workflow only triggers on `push: tags: v*.*.*`, but the `v1.1.0` tag push (and earlier `v1.0.2`, `v1.0.3`) did not trigger it. As a result, no Docker image was published to GHCR for these versions.

Root cause is likely that release-please uses a GitHub App token to push tags, and the token scope changed between `v1.0.1` (which did trigger) and later releases.

## Fix

Adds `workflow_dispatch` with a validated `tag` input so maintainers can manually trigger the build for an existing tag. This unblocks publishing `v1.1.0` immediately.

## Security

- `inputs.tag` is validated against `^v[0-9]+\.[0-9]+\.[0-9]+$` before use in any shell command
- All expressions passed through `env:` blocks, not inline in `run:` steps
- `workflow_dispatch` is only available to repo maintainers

## Compliance (do-app-action constitution)

- §VIII (Token Sufficiency): uses only `GITHUB_TOKEN` with `packages: write` ✅
- §VII (Pinned Dependencies): no new action references ✅
- §IX (Confidentiality): no internal names in committed text ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)