### PR TITLE
fix(ci): move floating major tag to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     # workflows:write is required to force-push a floating major tag (e.g., v1)
     # when the repository contains workflow files. Without this scope, git push
-    # is rejected with "refusing to allow OAuth App to create or update workflow".
+    # is rejected with "refusing to allow a GitHub App to create or update workflow".
     permissions:
       contents: write
       pull-requests: write
@@ -48,6 +48,13 @@ jobs:
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout (for floating tag push)
+        if: steps.release.outputs.release_created == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Move floating major tag
         if: steps.release.outputs.release_created == 'true'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,13 +1,14 @@
 # Release Please Workflow
 #
 # Purpose
-# Automates versioning, changelog generation, and GitHub releases for
-# do-app-action using conventional commits.
+# Automates versioning, changelog generation, GitHub releases, and floating
+# major-version tag management for do-app-action using conventional commits.
 #
 # How it works:
 #   1. On push to main → creates/updates a release PR with changelog + version bump
 #   2. On release PR merge → creates GitHub Release + git tag (e.g., v1.2.3)
-#   3. The tag triggers release.yml which moves the floating major tag (v1)
+#   3. After the release tag is created, moves the floating major tag (e.g., v1)
+#      so callers using @v1 automatically get the latest stable release.
 #
 # Conventional commits drive changelog generation:
 #   feat(archive): add pagination support    → Features
@@ -31,8 +32,31 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    # workflows:write is required to force-push a floating major tag (e.g., v1)
+    # when the repository contains workflow files. Without this scope, git push
+    # is rejected with "refusing to allow OAuth App to create or update workflow".
+    permissions:
+      contents: write
+      pull-requests: write
+      workflows: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Run Release Please
+        id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Move floating major tag
+        if: steps.release.outputs.release_created == 'true'
+        env:
+          TAG: ${{ steps.release.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          MAJOR=$(echo "$TAG" | sed 's/\(v[0-9]*\)\..*/\1/')
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -fa "$MAJOR" -m "Update $MAJOR to $TAG" "$TAG"
+          git push origin "$MAJOR" --force

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,6 +63,7 @@ jobs:
         run: |
           set -euo pipefail
           MAJOR=$(echo "$TAG" | sed 's/\(v[0-9]*\)\..*/\1/')
+          git fetch --tags origin "$TAG"
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -fa "$MAJOR" -m "Update $MAJOR to $TAG" "$TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,10 @@
 # Triggered by semver tags pushed by release-please (e.g., v1.2.3).
 # release-please already creates the GitHub Release; this workflow:
 #   1. Builds and pushes the Docker image to GHCR (publish-image).
-#   2. Moves the floating major-version git tag, e.g. v1 → v1.2.3 (move-major-tag).
 #
-# publish-image runs first so the GHCR image at :v1 exists before the
-# floating git tag is updated and callers start using the new version.
+# The floating major-version git tag (e.g. v1 → v1.2.3) is moved by
+# release-please.yml immediately after the release is created, so it does
+# not need to be handled here.
 
 name: Release
 
@@ -69,25 +69,3 @@ jobs:
             ${{ steps.tags.outputs.versioned }}
             ${{ steps.tags.outputs.major }}
 
-  move-major-tag:
-    name: Move floating major tag
-    needs: publish-image
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          ref: ${{ inputs.tag || github.ref }}
-          fetch-depth: 0
-
-      - name: Move floating major tag
-        env:
-          TAG: ${{ inputs.tag || github.ref_name }}
-        run: |
-          MAJOR=$(echo "$TAG" | sed 's/\(v[0-9]*\)\..*/\1/')
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -fa "$MAJOR" -m "Update $MAJOR to $TAG" "$TAG"
-          git push origin "$MAJOR" --force


### PR DESCRIPTION
## Summary

- Adds a **Move floating major tag** step to `release-please.yml`, fired only when `release_created == 'true'`
- Declares `workflows: write` on the job-level `permissions` block (with explanatory comment) so `GITHUB_TOKEN` can force-push a tag whose ref tree contains workflow files
- Removes the `move-major-tag` job and its `needs: publish-image` dependency from `release.yml` entirely
- Updates header comments in both files to reflect the new responsibility split

## Root cause

`release.yml` runs on a tag-push trigger. At that point `GITHUB_TOKEN` is scoped to the tag event context, and GitHub rejects force-pushing a tag containing workflow files unless `workflows: write` is explicitly declared. The job-level `permissions` block in `release.yml` only had `contents: write`, causing the push to silently fail or be rejected.

Moving the step into `release-please.yml` (which runs on `push` to `main` and already owns the release lifecycle) lets us declare `workflows: write` once, cleanly, right where the tag is created.

## Security note

`TAG` is sourced from `steps.release.outputs.tag_name` — release-please's own output, not user-controlled input. It is passed via `env:` into the shell script (not inline `${{ }}` interpolation), so there is no injection surface.

## Test plan

- [ ] Merge a conventional-commit PR to trigger release-please
- [ ] Confirm release-please creates the semver tag and GitHub Release
- [ ] Confirm the Move floating major tag step fires and `v1` is updated to point to the new tag
- [ ] Confirm `release.yml` runs only `publish-image` with no `move-major-tag` job

## Compliance Statement

| Principle | Impact | Status |
|-----------|--------|--------|
| VI (Conventional Commits / Release Automation) | Fix restores correct automated floating-tag behavior after release | Compliant |
| VII (Minimal, Pinned Dependencies) | No new actions added; existing pinned SHA unchanged | Compliant |
| VIII (GitHub Token Sufficiency) | Uses only `GITHUB_TOKEN` with explicitly declared least-privilege scopes; `workflows: write` is the minimum required for this operation and is documented with a comment | Compliant |
| IX (Org Info Confidentiality) | No org-specific references in any committed artifact | Compliant |
| XI (No Stranded Work) | Branch pushed, PR opened | Compliant |
| XII (Documentation as Artifact) | Header comments in both workflow files updated to reflect new responsibility split; no action inputs/outputs changed | Compliant |

Agent-generated: implements floating-tag consolidation into release-please.yml as requested in issue #37. All workflow changes are targeted to the stated fix with no speculative scope expansion.

Closes #37.