### PR TITLE
fix(ci): drop the invalid workflows permission that killed release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,13 +32,22 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    # workflows:write is required to force-push a floating major tag (e.g., v1)
-    # when the repository contains workflow files. Without this scope, git push
-    # is rejected with "refusing to allow a GitHub App to create or update workflow".
+    # NOTE: there is no `workflows` permission scope. It was declared here
+    # until 2026-08-13, which made this file INVALID — GitHub rejected it
+    # outright, so every run since was a zero-job startup failure and
+    # release-please never actually ran. The failure is silent: the run is
+    # attributed to `push`, shows the file path instead of the workflow name,
+    # and creates no check run, so nothing surfaces it.
+    #
+    # The premise was wrong as well as the syntax. The workflow-file push
+    # restriction applies to creating or updating workflow FILES with the
+    # token; moving a lightweight tag that happens to point at a commit
+    # containing workflow files is not affected. If a future change does need
+    # to write workflow files, that requires an app token or PAT — no
+    # `permissions:` value grants it.
     permissions:
       contents: write
       pull-requests: write
-      workflows: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
## Summary

**There is no `workflows` permission scope.** Declaring `workflows: write` on the `release-please` job made `release-please.yml` invalid, so GitHub rejected the file outright — **release-please has not run at all**. Every push since at least 2026-07-07 is a zero-job startup failure.

```
  2026-08-13  ci/add-pr-title-lint     push  failure
  2026-07-21  dependabot/go_modules/   push  failure
  2026-07-07  dependabot/github_acti   push  failure
```

## Why a month of dead release automation went unnoticed

The failure leaves almost no trace:

- the run has **zero jobs** and is attributed to **`push`**
- it lists the **file path** instead of the workflow name
- **no check run is created**, so `gh pr checks` shows nothing wrong

Nobody looks at a workflow that never reports. This is the third instance of the same class found today — the invalid `timeout-minutes` key on a reusable-workflow job in blavity/bmg-scheduled-publisher#24, and the same-shaped break in blavity/travelnoire-ui#1254 where a compliance gate had been dead since the day it was added.

## The premise was wrong too, not just the syntax

The comment claimed the scope was needed to force-push the floating major tag when the repo contains workflow files. The workflow-file push restriction applies to creating or updating workflow **files** with the token; moving a lightweight tag that happens to point at a commit containing workflow files is not affected. And if a future change genuinely does need to write workflow files, that requires an app token or PAT — no `permissions:` value grants it.

The replacement comment records both points so the scope does not come back.

## Test plan

- [ ] The `Release Please` workflow **starts** on the next push to `main` — i.e. it appears by name with real jobs, not as a path-named zero-job failure
- [ ] It opens a Version PR if there are releasable commits since the last tag
- [ ] On merging that Version PR, the release is cut and the floating `v1` tag moves — confirming the tag push works without the phantom scope

Found while adding the PR-title lint gate for https://github.com/blavity/shared-workflows/issues/1698.

🤖 Generated with [Claude Code](https://claude.com/claude-code)