### PR TITLE
chore(renovate): add shared preset config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,20 @@
+{
+  // renovate.json5 — managed by blavity/renovate-config onboarding
+  // Extends the org-wide shared preset. Add repo-specific overrides below.
+  // Preset docs: https://github.com/blavity/renovate-config
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["github>blavity/renovate-config"],
+  packageRules: [
+    {
+      // Group Go module updates
+      matchManagers: ["gomod"],
+      groupName: "go-modules",
+    },
+    {
+      // Group mise tool version updates. Exclude node — the org preset already groups it into node-runtime-version.
+      matchManagers: ["mise"],
+      excludePackageNames: ["node"],
+      groupName: "mise-tools",
+    }
+  ]
+}


### PR DESCRIPTION
## Renovate onboarding — shared preset

This PR configures Renovate to use the [Blavity shared preset](https://github.com/blavity/renovate-config).

**Previous config status:** No Renovate config
**Detected stacks:** docker, github-actions, go, mise

### What this config does

- Extends `github>blavity/renovate-config` for org-wide defaults (schedules, automerge rules, grouping, merge confidence badges, OSV vulnerability alerts)
- Adds stack-specific `packageRules` grouping where applicable

### What the shared preset provides

- A package cooldown before updates are proposed, plus bounded PR concurrency
- Narrow automerge after CI passes: npm/bun `devDependencies` and `@types/*` (patch + minor, non-0.x), lock file maintenance, and Docker + third-party GitHub Actions digest refreshes
- Runtime dependencies, majors, security fixes and `needs-migration` bumps always wait for a human — [opt out of automerge entirely](https://github.com/blavity/renovate-config/blob/main/docs/preset-guide.md#auto-merge-tiers-2026-08-13) if unattended merges are unacceptable for this repo
- Security vulnerability alerts (immediate, cooldown bypassed, grouped one PR per manager)
- Merge confidence badges on all PRs
- Lock file maintenance weekly (before 4am Monday ET)
- GitHub Actions digest pinning

---
_Opened by [onboard.js](https://github.com/blavity/renovate-config/blob/main/scripts/onboard.js)_
